### PR TITLE
Ignore saveCache error

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -45,7 +45,11 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
   if (cacheHit === undefined) {
     core.startGroup(`Save cache`)
     core.info(`Saving cache to key ${cacheKey}`)
-    await cache.saveCache([binDir], cacheKey)
+    try {
+      await cache.saveCache([binDir], cacheKey)
+    } catch (error) {
+      core.warning(`could not save cache: ${error}`)
+    }
     core.endGroup()
   }
 


### PR DESCRIPTION
Sometimes this action fails due to the following error:

```
  Saving cache to key akoi-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  Error: Unable to reserve cache with key akoi-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855, another job may be creating this cache.
```

This PR will ignore the error of `saveCache`.