### PR TITLE
Fix digest of cache key

### DIFF
--- a/src/digest.ts
+++ b/src/digest.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'crypto'
+import * as fs from 'fs'
+
+export const digest = async (name: string): Promise<string> => {
+  const h = createHash('sha256')
+  const f = fs.createReadStream(name)
+  f.pipe(h)
+  const p = new Promise<string>((resolve, reject) => {
+    f.on('end', () => {
+      resolve(h.digest('hex'))
+    })
+    f.on('error', reject)
+  })
+  p.finally(() => f.close())
+  return p
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,9 +3,8 @@ import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as io from '@actions/io'
 import * as tc from '@actions/tool-cache'
-import { createHash } from 'crypto'
-import * as fs from 'fs'
 import * as os from 'os'
+import { digest } from './digest'
 
 type Inputs = {
   config: string
@@ -75,18 +74,3 @@ const installAkoi = async (version: string): Promise<string> => {
   await exec.exec('chmod', ['+x', `${cacheDir}/akoi`])
   return cacheDir
 }
-
-const digest = async (name: string): Promise<string> =>
-  new Promise((resolve, reject) => {
-    try {
-      const h = createHash('sha256')
-      const f = fs.createReadStream(name)
-      f.pipe(h)
-      f.close()
-      h.end(() => {
-        resolve(h.digest('hex'))
-      })
-    } catch (error) {
-      reject(error)
-    }
-  })

--- a/tests/digest.test.ts
+++ b/tests/digest.test.ts
@@ -1,0 +1,8 @@
+import { digest } from '../src/digest'
+
+test('digest', async () => {
+  // % shasum -a 256 tests/fixtures/fixture.txt
+  // 4a1e67f2fe1d1cc7b31d0ca2ec441da4778203a036a77da10344c85e24ff0f92  tests/fixtures/fixture.txt
+  const actual = await digest(`${__dirname}/fixtures/fixture.txt`)
+  expect(actual).toBe('4a1e67f2fe1d1cc7b31d0ca2ec441da4778203a036a77da10344c85e24ff0f92')
+})

--- a/tests/fixtures/fixture.txt
+++ b/tests/fixtures/fixture.txt
@@ -1,0 +1,2 @@
+hello
+world

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,3 +1,0 @@
-test('run successfully', async () => {
-  //TODO
-})


### PR DESCRIPTION
Currently cache key becomes always `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` but it should be a digest of akoi.yml.

It seems the implementation is broken:

```
% echo -n '' | shasum -a 256
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  -
```